### PR TITLE
add redirect result to localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ const connector = new DedicatedWalletConnector({
 })
 ```
 
+To retrieve the Magic redirect result when a user is authenticated and logged in, use `JSON.parse(localStorage.getItem("magicRedirectResult"))`. This will give you access to the redirect result object. The object will be removed from localStorage once the user disconnects.
+
 
 ## 📲 Enable SMS Authentication
 

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -178,6 +178,7 @@ export function dedicatedWalletConnector({
       try {
         const magic = getMagicSDK()
         await magic?.wallet.disconnect()
+        localStorage.removeItem('magicRedirectResult')
         config.emitter.emit('disconnect')
       } catch (error) {
         console.error('Error disconnecting from Magic SDK:', error)
@@ -221,11 +222,15 @@ export function dedicatedWalletConnector({
         }
 
         const isLoggedIn = await magic.user.isLoggedIn()
+        const result = await magic.oauth.getRedirectResult()
+        if (result) {
+          localStorage.setItem('magicRedirectResult', JSON.stringify(result))
+        }
+
         if (isLoggedIn) return true
 
-        const result = await magic.oauth.getRedirectResult()
         return result !== null
-      } catch {}
+      } catch { }
       return false
     },
 


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Add OAuth redirect result to localStorage on log in
- Remove redirect result from localStorage on disconnect

What is the current behavior? (You can also link to an open issue here)

- There is no way to extract the redirect result from the WAGMI connector when using OAuth.

What is the new behavior (if this is a feature change)?

- If a user is authenticated and logged in, using `JSON.parse(localStorage.getItem("magicRedirectResult"))` will return the redirect object.