### PR TITLE
fixes lost session

### DIFF
--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -177,7 +177,7 @@ export function dedicatedWalletConnector({
     disconnect: async () => {
       try {
         const magic = getMagicSDK()
-        await magic?.wallet.disconnect()
+        await magic?.user.logout()
         localStorage.removeItem('magicRedirectResult')
         config.emitter.emit('disconnect')
       } catch (error) {
@@ -222,13 +222,13 @@ export function dedicatedWalletConnector({
         }
 
         const isLoggedIn = await magic.user.isLoggedIn()
+        if (isLoggedIn) return true
+
         const result = await magic.oauth.getRedirectResult()
         if (result) {
           localStorage.setItem('magicRedirectResult', JSON.stringify(result))
         }
-
-        if (isLoggedIn) return true
-
+        
         return result !== null
       } catch {}
       return false

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -228,7 +228,6 @@ export function dedicatedWalletConnector({
         if (result) {
           localStorage.setItem('magicRedirectResult', JSON.stringify(result))
         }
-        
         return result !== null
       } catch {}
       return false

--- a/src/lib/modal/styles.ts
+++ b/src/lib/modal/styles.ts
@@ -42,8 +42,11 @@ export const modalStyles = (accentColor = '#6452f7') => `
   .Magic__closeButton {
     position: absolute;
     top: 0;
+    width: 40px;
+    height: 40px;
+    top: 15px;
     right: 15px;
-    padding: 10px;
+    padding: 6px 10px 10px 10px;
     border: none;
     background-color: transparent;
     cursor: pointer;
@@ -120,6 +123,7 @@ export const modalStyles = (accentColor = '#6452f7') => `
       text-align: center;
       color: #D6D6D6;
       font-size: 14px;
+      margin-bottom: 8px;
   }
   .Magic__dark .Magic__divider {
     color: #444;
@@ -147,13 +151,13 @@ export const modalStyles = (accentColor = '#6452f7') => `
     align-items: center;
     flex-wrap: wrap;
     justify-content: center;
-    gap: 10px;
+    gap: 20px;
     width: 90%;
   }
   .Magic__oauthButton{
     display: block;
-    padding: 5px;
-    border: none;
+    width: fit-content;
+    padding: 0;
     background-color: transparent;
     cursor: pointer;
     border-radius: 100px;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix.

- **What is the current behavior?** (You can also link to an open issue here)

When refreshing the page after connecting, the wagmi connection returns false, causing it to appear as if a user is not authenticated. This was due to a misconfiguration in the order of operations within the `isAuthorized` method.

- **What is the new behavior (if this is a feature change)?**

The dedicatedWalletConnector now properly sets the the oauth state within the `isAuthorized` method and calls the Magic methods in the correct order.

- **Other information**:

Includes fixes for OAuth and close button sizing/placement.

**Before:**
![Screenshot 2024-11-25 at 5 38 16 PM](https://github.com/user-attachments/assets/5d52ecf5-e52b-4bcf-915f-491f8965c37f)

**After:**
![Screenshot 2024-11-25 at 5 13 51 PM](https://github.com/user-attachments/assets/2658a6b2-f316-45aa-9b50-156f25d7ba57)

