### PR TITLE
Bug fix: Deepcloning Options

### DIFF
--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -242,8 +242,11 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
       const newOptions: MagicOptions = {
         ...options,
         connectorType: 'dedicated',
+        magicSdkConfiguration: {
+          ...options.magicSdkConfiguration,
+          network,
+        },
       };
-      newOptions.magicSdkConfiguration!.network = network;
 
       const { getAccount, getMagicSDK, getProvider, onAccountsChanged } = magicConnector({
         chains,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
In the dedicatedWalletConnector's switchChain method, the code was mutating the original options object due to improper cloning. Specifically, it was creating a shallow clone of the options object using the spread operator, but then directly modifying the magicSdkConfiguration.network property on this new object. Since nested objects are passed by reference, this was permanently changing the original options object's network configuration.

- **What is the new behavior (if this is a feature change)?**
The fix properly deep clones the magicSdkConfiguration object when creating newOptions, the original options object remains unchanged during network switching.

- **Other information**:
This issue was flagged by a self serve developer team..