### PR TITLE
Don't fetch oauth redirect result if no providers are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# @magiclabs/wagmi-magic-connector
+# @likecoin/wagmi-magic-connector
+
+## 2.4.0
+
+### Minor Changes
+
+- Upgrade Magic SDK from v29 to v33 (`magic-sdk@^33.4.1`, `@magic-ext/oauth2@^15.3.1`)
+- Add `@magic-ext/evm@^1.2.1` for native EVM chain switching via `magic.evm.switchChain()`
+- Rewrite `switchChain()` to use EVMExtension instead of re-instantiating the entire Magic SDK
+- Update `publicAddress` access to `wallets.ethereum.publicAddress` (Magic SDK v31 breaking change)
+- Add `customLoginText` option to customize modal login button text
+- Lazy-load `magic-sdk`, `@magic-ext/oauth2`, and `@magic-ext/evm` for smaller initial bundle
+- Move `@wagmi/core` to peer dependencies
+- Remove unused dependencies
+- Publish as `@likecoin/wagmi-magic-connector` fork
 
 ## 2.3.0
 

--- a/README.md
+++ b/README.md
@@ -29,57 +29,37 @@ Special thanks to the [Everipedia](https://github.com/EveripediaNetwork) team fo
   - [**Example repositories:**](#example-repositories)
 
 # ⬇️ Install
-Two versions of the `wagmi-magic-connector` are available, each designed to support different WAGMI versions. 
 
-Note: **It is crucial not to mix up these versions to ensure compatibility and functionality.**
+This is a fork of `@magiclabs/wagmi-connector` with the following changes:
+- Upgraded to Magic SDK v33 with `@magic-ext/evm` for native EVM chain switching
+- Lazy-loaded Magic SDK imports for smaller initial bundle
+- Moved `@wagmi/core` to peer dependencies
+- Added `customLoginText` option for modal button text
+- Removed unused dependencies
 
-**V1**
-This version utilizes WAGMI version 1. To install, use the following command:
+Requires WAGMI v2 and viem v2.
 
-`npm install @magiclabs/wagmi-connector@1.1.5`
-or
-`yarn install @magiclabs/wagmi-connector@1.1.5`
-
-**V2 (Beta)**
-This version utilizes and includes the latest WAGMI v2 features.
-
-To install, use the following command:
-
-`npm install @magiclabs/wagmi-connector`
-or
-`yarn install @magiclabs/wagmi-connector`
-
-We actively encourage the community to participate in testing the versions of `wagmi-magic-connector` and to report [any issues or suggestions](https://github.com/magiclabs/wagmi-magic-connector/issues/new/choose) for improvement. Your feedback is invaluable in helping us enhance the quality and stability of the connector.
+```sh
+npm install @likecoin/wagmi-magic-connector
+```
 
 # 🔎 Package TL;DR
 
-The package contains two main connector classes: `DedicatedWalletConnector` & `UniversalWalletConnector`
-
-`DedicatedWalletConnector` is a connector integrated to the [Dedicated Wallet](https://magic.link/docs/dedicated/overview)
-product. It is useful if you need to assign an address to your user. 
-
-`UniversalWalletConnector` is a connector integrated to the [Universal Wallet](https://magic.link/docs/universal/overview)
-product. It can be used to assign a read-write wallet to your user.
-
-DEPRECATED: `MagicAuthConnector` and `MagicConnectConnector` have been replaced by `DedicatedWalletConnector` and `UniversalWalletConnector` in order to line up with Magic's [product names changes](https://magic.link/docs/universal/resources/faqs#why-were-magic-product-names-changed-from-magic-connect-and-magic-auth). However, they are still usable and will function as they did before.
+This package provides `dedicatedWalletConnector`, a [WAGMI](https://wagmi.sh/) connector integrated with Magic's [Dedicated Wallet](https://magic.link/docs/dedicated/overview). It supports email OTP, SMS, and OAuth login, as well as EVM chain switching via `@magic-ext/evm`.
 
 # ⭐ Usage
 
 ```javascript
-import { dedicatedWalletConnector, universalWalletConnector } from '@magiclabs/wagmi-connector';
+import { dedicatedWalletConnector } from '@likecoin/wagmi-magic-connector';
 
-// Dedicated Wallet integration
 const connector = dedicatedWalletConnector({
+  chains,
   options: {
     apiKey: YOUR_MAGIC_PUBLISHABLE_API_KEY, //required
-    //...Other options
-  },
-});
-
-// Universal Wallet integration 
-const connector = universalWalletConnector({
-  options: {
-    apiKey: YOUR_MAGIC_PUBLISHABLE_API_KEY, //required
+    networks: [
+      { rpcUrl: 'https://mainnet.infura.io/v3/...', chainId: 1 },
+      { rpcUrl: 'https://polygon-rpc.com/', chainId: 137 },
+    ],
     //...Other options
   },
 });
@@ -91,17 +71,19 @@ const connector = universalWalletConnector({
 
 The following can be passed to connector options object:
 
-| Key                   | Value                      | `DedicatedWalletConnector` support | `UniversalWalletConnector` support | Description                                                                                                                                                                    |
-|-----------------------|----------------------------|------------------------------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| accentColor           | css color (hex/rgb/etc...) | ✔️	                          | ✔️                              | 🎨 (Optional) Makes modal to use the custom accentColor instead of default purple                                                                                              |
-| isDarkMode            | true / false               | ✔️	                          | ✔️                              | 🎨 (Optional) Makes modal dark mode if true. Default value is false                                                                                                            |
-| customLogo            | path_to_logo / url         | ✔️	                          | ✔️                              | 🎨 (Optional) Makes modal to use the custom logo instead of default magic logo                                                                                                 |
-| customHeaderText            | string                     | ✔️	                          | ✔️                              | 🎨 (Optional) Makes modal to use the custom header text instead of default text at the bottom of logo                                                                          |
-| enableSMSLogin        | true / false               | ✔️	                          | ❌                               | 🌟 (Optional) Makes modal to enable SMS login if true. Default value is false                                                                                                  |
-| enableEmailLogin      | true / false               | ✔️	                          | ❌                               | 🌟 (Optional) Makes modal to disable Email login if false. Default value is true                                                                                               |
-| OAuthOptions          | object                     | ✔️	                          | ❌                               | 🌟 (Optional) Makes modal to enable OAuth login according to configuration passed.                                                                                             |
-| magicSdkConfiguration | object                     | ✔️	                          | ✔️                              | 🛠️ (Optional) Pass additional options to Magic constructor (refer [Magic API documentation](https://magic.link/docs/api-reference/client-side-sdks/web#constructor) for more) |
-| networks              | array of EthNetworkConfiguration | ❌                     | ✔️                              | 🛠️ (Optional) Pass the list of network compatible to switch networks |
+| Key                   | Value                      | Description                                                                                                                                                                    |
+|-----------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| apiKey                | string                     | 🔑 (Required) Your Magic publishable API key                                                                                                                                  |
+| accentColor           | css color (hex/rgb/etc...) | 🎨 (Optional) Custom accent color for the modal. Default is purple                                                                                                            |
+| isDarkMode            | true / false               | 🎨 (Optional) Enable dark mode for the modal. Default is false                                                                                                                |
+| customLogo            | path_to_logo / url         | 🎨 (Optional) Custom logo for the modal instead of the default Magic logo                                                                                                     |
+| customHeaderText      | string                     | 🎨 (Optional) Custom header text for the modal. Default is "Magic"                                                                                                            |
+| customLoginText       | string                     | 🎨 (Optional) Custom login button text. Default is "Log in / Sign up"                                                                                                         |
+| enableSMSLogin        | true / false               | 🌟 (Optional) Enable SMS login. Default is false                                                                                                                              |
+| enableEmailLogin      | true / false               | 🌟 (Optional) Enable Email login. Default is true                                                                                                                             |
+| oauthOptions          | object                     | 🌟 (Optional) OAuth login configuration. See below                                                                                                                            |
+| magicSdkConfiguration | object                     | 🛠️ (Optional) Additional options for the Magic constructor ([docs](https://magic.link/docs/api-reference/client-side-sdks/web#constructor))                                  |
+| networks              | array                      | 🛠️ (Optional) List of `{ rpcUrl, chainId }` objects for EVM chain switching via `@magic-ext/evm`                                                                             |
 
 ## `options.OAuthOptions`
 
@@ -134,13 +116,13 @@ You can provide a callback URL to redirect the user to after authentication. the
 
 # 🍀 Supported Logins
 
-| Key                        | `DedicatedWalletConnector` support | `UniversalWalletConnector` support |
-|----------------------------|------------------------------|---------------------------------|
-| Email                      | ✔️	                          | ✔️	                             |
-| SMS                        | ✔️	                          | ❌                               |
-| Social Logins              | ✔️	                          | ❌                               |
-| WebAuthn                   | ❌                            | ❌                               |
-| Multifactor Authentication | ❌                            | ❌                               |
+| Method                     | Supported |
+|----------------------------|-----------|
+| Email OTP                  | ✔️        |
+| SMS                        | ✔️        |
+| Social Logins (OAuth)      | ✔️        |
+| WebAuthn                   | ❌        |
+| Multifactor Authentication | ❌        |
 
 # 🔆 Examples
 
@@ -192,21 +174,22 @@ const connector = dedicatedWalletConnector({
   },
 });
 ```
-  
+
 
 ## 🎨 Modal Customization
 
 You can customize the modal's theme, default accent color, logo and header text.
 
 ```javascript
-import { dedicatedWalletConnector } from '@magiclabs/wagmi-connector';
+import { dedicatedWalletConnector } from '@likecoin/wagmi-magic-connector';
 
 const connector = dedicatedWalletConnector({
   options: {
     apiKey: YOUR_MAGIC_PUBLISHABLE_API_KEY,
     accentColor: '#ff0000',
     customLogo: 'https://example.com/logo.png',
-    headerText: 'Login to your account',
+    customHeaderText: 'Login to your account',
+    customLoginText: 'Sign in',
     isDarkMode: true,
   },
 });
@@ -224,7 +207,7 @@ To use the connector with Rainbow kit, create a new file `RainbowMagicConnector.
 ```javascript
 // RainbowMagicConnector.ts
 
-import { dedicatedWalletConnector } from '@magiclabs/wagmi-connector'
+import { dedicatedWalletConnector } from '@likecoin/wagmi-magic-connector'
 import { Wallet, WalletDetailsParams } from '@rainbow-me/rainbowkit'
 import { CreateWalletFn } from '@rainbow-me/rainbowkit/dist/wallets/Wallet'
 import { Chain } from 'wagmi/chains'
@@ -316,6 +299,6 @@ export default MyApp;
 
 This procedure might change depending on the version of Rainbow kit you are using so please check the documentation of the Rainbow kit if it is not working.
 
-## **Example repositories:** 
+## **Example repositories:**
 - https://github.com/Royal-lobster/vanilla-magic-example
 - https://github.com/Royal-lobster/rainbow-magic-example (With Rainbowkit 🌈)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@magic-ext/oauth2": "^11.4.1",
-    "@wagmi/core": "^2.10.4",
     "magic-sdk": "29.4.2"
   },
   "devDependencies": {
@@ -45,6 +44,7 @@
     "viem": "2.x"
   },
   "peerDependencies": {
+    "@wagmi/core": "^2.10.4 || ^3.0.0",
     "viem": "2.x"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@magic-ext/oauth2": "^11.4.1",
-    "magic-sdk": "29.4.2"
+    "@magic-ext/evm": "^1.2.1",
+    "@magic-ext/oauth2": "^15.3.1",
+    "magic-sdk": "^33.4.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@magic-ext/oauth2": "^11.4.1",
-    "@wagmi/connectors": "^5.0.6",
     "@wagmi/core": "^2.10.4",
     "magic-sdk": "29.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@magiclabs/wagmi-connector",
-  "version": "2.3.2",
+  "name": "@likecoin/wagmi-magic-connector",
+  "version": "2.4.0",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
-  "repository": "https://github.com/magiclabs/wagmi-magic-connector",
+  "repository": "https://github.com/likecoin/wagmi-magic-connector",
   "license": "MIT",
   "keywords": [
     "wagmi",

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -71,6 +71,7 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
       isDarkMode: options.isDarkMode,
       customLogo: options.customLogo,
       customHeaderText: options.customHeaderText,
+      customLoginText: options.customLoginText,
       enableSMSLogin: enableSMSLogin,
       enableEmailLogin: enableEmailLogin,
       oauthProviders,

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -1,7 +1,7 @@
 import type { OAuthProvider } from '@magic-ext/oauth2';
 import type { Magic } from 'magic-sdk';
 import { createConnector } from '@wagmi/core';
-import { type Address, UserRejectedRequestError, getAddress } from 'viem';
+import { UserRejectedRequestError, getAddress } from 'viem';
 import { createModal } from '../modal/view';
 import { normalizeChainId } from '../utils';
 import { IS_SERVER, type MagicConnectorParams, type MagicOptions, magicConnector } from './magicConnector';
@@ -50,18 +50,6 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
     chains,
     options: { ...options, connectorType: 'dedicated' },
   });
-
-  const registerProviderEventListeners = (
-    provider: any,
-    onChainChanged: (chain: string) => void,
-    onDisconnect: () => void,
-  ) => {
-    if (provider.on) {
-      provider.on('accountsChanged', onAccountsChanged);
-      provider.on('chainChanged', (chain: string) => onChainChanged(chain));
-      provider.on('disconnect', onDisconnect);
-    }
-  };
 
   const oauthProviders = options.oauthOptions?.providers ?? [];
   const oauthCallbackUrl = options.oauthOptions?.callbackUrl;
@@ -208,60 +196,17 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
         throw new Error(`Unsupported chainId: ${chainId}`);
       }
 
-      const network = options.networks.find(x => {
-        if (typeof x === 'object' && x.chainId) {
-          return normalizeChainId(x.chainId) === normalizedChainId;
-        }
+      const magic = await this.getMagic();
+      await (magic as any).evm.switchChain(normalizedChainId);
 
-        if (typeof x === 'string') {
-          const networkMap: Record<string, number> = {
-            mainnet: 1,
-            sepolia: 11155111,
-            goerli: 5,
-          };
+      const metadata = await magic.user.getInfo();
+      const account = metadata?.wallets?.ethereum?.publicAddress;
+      if (!account) throw new Error('Failed to get account after chain switch');
 
-          const networkId = networkMap[x.toLowerCase()] ?? null;
-
-          return networkId !== null && normalizeChainId(networkId) === normalizedChainId;
-        }
-
-        return normalizeChainId(x as unknown as bigint | number | string) === normalizedChainId;
-      });
-
-      const provider = (await this.getProvider()) as any;
-
-      if (provider?.off) {
-        provider.off('accountsChanged', this.onAccountsChanged);
-        provider.off('chainChanged', this.onChainChanged);
-        provider.off('disconnect', this.onDisconnect);
-      }
-
-      const newOptions: MagicOptions = {
-        ...options,
-        connectorType: 'dedicated',
-        magicSdkConfiguration: {
-          ...options.magicSdkConfiguration,
-          network,
-        },
-      };
-
-      const { getAccount, getMagicSDK, getProvider, onAccountsChanged } = magicConnector({
-        chains,
-        options: newOptions,
-      });
-
-      this.getAccount = getAccount;
-      this.magic = await getMagicSDK();
-      this.getProvider = getProvider;
-      this.onAccountsChanged = onAccountsChanged;
-
-      const metadata = await this.magic?.user.getInfo();
-      const account = metadata?.publicAddress as Address;
-
-      registerProviderEventListeners(this.magic!.rpcProvider, this.onChainChanged, this.onDisconnect);
+      const address = getAddress(account);
       this.onChainChanged(chain.id.toString());
-      config.emitter.emit('change', { accounts: [account] });
-      this.onAccountsChanged([account]);
+      config.emitter.emit('change', { accounts: [address] });
+      this.onAccountsChanged([address]);
       return chain;
     },
 

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -272,11 +272,13 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
         const isLoggedIn = await magic.user.isLoggedIn();
         if (isLoggedIn) return true;
 
-        const result = await magic.oauth2.getRedirectResult();
-        if (result) {
-          localStorage.setItem('magicRedirectResult', JSON.stringify(result));
+        if (oauthProviders?.length > 0) {
+          const result = await magic.oauth2.getRedirectResult();
+          if (result) {
+            localStorage.setItem('magicRedirectResult', JSON.stringify(result));
+          }
+          return result !== null;
         }
-        return result !== null;
       } catch {}
       return false;
     },

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -81,16 +81,23 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
     return output;
   };
 
-  return createConnector(config => ({
+  let magic: Magic | undefined;
+  let magicPromise: Promise<Magic> | undefined;
+
+  const connectorFn = createConnector(config => ({
     id,
     type,
     name,
-    magic: undefined as Magic | undefined,
     async getMagic(): Promise<Magic> {
-      if (!this.magic) {
-        this.magic = await getMagicSDK();
+      if (!magicPromise) {
+        magicPromise = getMagicSDK()
+          .then(m => (magic = m))
+          .catch(error => {
+            magicPromise = undefined;
+            throw error;
+          });
       }
-      return this.magic;
+      return magicPromise;
     },
     getProvider,
     getAccount,
@@ -243,4 +250,16 @@ export function dedicatedWalletConnector({ chains, options }: DedicatedWalletCon
       config.emitter.emit('disconnect');
     },
   }));
+
+  // Expose `magic` as non-enumerable so wagmi's deepEqual doesn't
+  // traverse the Magic SDK's circular references and blow the stack.
+  return ((...args: Parameters<typeof connectorFn>) => {
+    const connector = connectorFn(...args);
+    Object.defineProperty(connector, 'magic', {
+      get: () => magic,
+      enumerable: false,
+      configurable: true,
+    });
+    return connector;
+  }) as typeof connectorFn;
 }

--- a/src/lib/connectors/magicConnector.ts
+++ b/src/lib/connectors/magicConnector.ts
@@ -11,6 +11,7 @@ export interface MagicOptions {
   isDarkMode?: boolean;
   customLogo?: string;
   customHeaderText?: string;
+  customLoginText?: string;
   connectorType?: 'dedicated' | 'universal';
   magicSdkConfiguration?: any;
   networks?: EthNetworkConfiguration[];

--- a/src/lib/modal/view.ts
+++ b/src/lib/modal/view.ts
@@ -21,6 +21,7 @@ export const createModal = async (props: {
   isDarkMode?: boolean;
   customLogo?: string;
   customHeaderText?: string;
+  customLoginText?: string;
   enableSMSLogin?: boolean;
   enableEmailLogin?: boolean;
   oauthProviders?: OAuthProvider[];
@@ -89,7 +90,7 @@ export const createModal = async (props: {
           ${
             props.enableSMSLogin || props.enableEmailLogin
               ? ` <button class="Magic__submitButton" type="submit">
-                Log in / Sign up
+                ${props.customLoginText || 'Log in / Sign up'}
               </button>`
               : ''
           }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A mitigation for https://github.com/magiclabs/wagmi-magic-connector/issues/51
Also minor performance improvement for those didn't need oauth

- **What is the current behavior?** (You can also link to an open issue here)
`magic.oauth.getRedirectResult()` is always called in `isAuthorized`

- **What is the new behavior (if this is a feature change)?**
`magic.oauth.getRedirectResult()` is only called if `options.oauthOptions.providers` is set

- **Other information**:
