### PR TITLE
fix: Update github action release setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,17 +4,27 @@ jobs:
   ci:
     name: Lint using ESLint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
 
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run ESLint
-        run: yarn eslint .
+        run: pnpm eslint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,11 @@
 name: Lint Checks
+
 on: [push]
+
 jobs:
   ci:
     name: Lint using ESLint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -16,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,25 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 22.x
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: ${{ matrix.node-version }}
 
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,27 +6,35 @@ jobs:
   release:
     name: Publish snapshot version
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     env:
       CI: true
     steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-version }}
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies1
+        run: pnpm install --frozen-lockfile
 
       - name: Publish
         uses: seek-oss/changesets-snapshot@v0
         with:
-          pre-publish: yarn build
+          pre-publish: pnpm build
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,9 +6,6 @@ jobs:
   release:
     name: Publish snapshot version
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20, 22]
     env:
       CI: true
     steps:
@@ -21,14 +18,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
 
-      - name: Install dependencies1
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magiclabs/wagmi-connector",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "build": "tsc -p tsconfig.json && tsc-esm-fix --target='dist' --ext='.js'",
     "lint": "eslint .",
     "watch:build": "tsc -p tsconfig.json -w",
-    "release": "yarn build && changeset publish"
+    "release": "pnpm build && changeset publish"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The release process was fixed by adding an action that enables the use of the `pnpm` package manager in the workflow.

This change also standardizes package management across the project. I’m not entirely sure if this was the original intention, but since only the `pnpm` lockfile existed (among the usual lockfiles), I decided to continue using `pnpm`.

Additionally, I updated the Node.js versions across the workflows to make them more consistent, as one was using 18, another 20, and another 22.

- **What is the current behavior?** (You can also link to an open issue here)
- The release workflow is currently broken, and the latest versions of this library are no longer being published automatically.

- **What is the new behavior (if this is a feature change)?**

- **Other information**: